### PR TITLE
Change spelling of CDT Cloud

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseURL = "https://www.eclipse.org/cdt-cloud"
 DefaultContentLanguage = "en"
-title = "CDT.cloud Blueprint"
+title = "CDT Cloud Blueprint"
 theme = "syna"
 
 [outputs]
@@ -15,7 +15,7 @@ lastmod = ["lastmod", ":git", "date"]
 
 [params]
   name = "Eclipse Foundation"
-  description = "CDT.cloud - open-source components for building web-based C/C++ tools"
+  description = "CDT Cloud - open-source components for building web-based C/C++ tools"
 
   [params.style]
     #background = "secondary"

--- a/content/_global/footer.md
+++ b/content/_global/footer.md
@@ -5,12 +5,12 @@ weight = 2000
 menu_title = "Related Projects"
 
 [asset]
-  title = "CDT.cloud Blueprint"
+  title = "CDT Cloud Blueprint"
   image = "logo.png"
-  text = "CDT.cloud"
+  text = "CDT Cloud"
   url = "#"
 +++
 
-#### CDT.cloud
+#### CDT Cloud
 
-CDT.cloud is a project hosted at the [Eclipse Foundation](https://www.eclipse.org/) organized within the embedded special interest group as part of the [Eclipse Cloud Developer Working Group](https://ecdtools.eclipse.org/), led by [EclipseSource](https://eclipsesource.com).
+CDT Cloud is a project hosted at the [Eclipse Foundation](https://www.eclipse.org/) organized within the embedded special interest group as part of the [Eclipse Cloud Developer Working Group](https://ecdtools.eclipse.org/), led by [EclipseSource](https://eclipsesource.com).

--- a/content/_global/nav.md
+++ b/content/_global/nav.md
@@ -5,6 +5,6 @@ weight = 0
 # Branding options
 [asset]
   image = "logo.png"
-  text = "CDT.cloud Blueprint"
-  title = "CDT.cloud Blueprint"
+  text = "CDT Cloud Blueprint"
+  title = "CDT Cloud Blueprint"
 +++

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,4 +1,4 @@
 +++
-title = "CDT.cloud Blueprint"
-description = "CDT.cloud Blueprint - a template for a web-based C/C++ tool"
+title = "CDT Cloud Blueprint"
+description = "CDT Cloud Blueprint - a template for a web-based C/C++ tool"
 +++

--- a/content/_index/blueprint/index.md
+++ b/content/_index/blueprint/index.md
@@ -24,7 +24,7 @@ CDT Cloud Blueprint is in an early alpha state and undergoing active development
 
 * Check out the [development plan](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/milestone/1) for Release 1.0
 * For the current up to date development version of CDT Cloud Blueprint including a Docker based development build, see the [Github repository](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint)
-* Prereleases of CDT.Cloud Blueprint are available to be [downloaded and installed](https://download.eclipse.org/theia/cdt-cloud/)
+* Prereleases of CDT Cloud Blueprint are available to be [downloaded and installed](https://download.eclipse.org/theia/cdt-cloud/)
 
 [Follow us on twitter](https://twitter.com/CdtCloud") to be notified about recent updates to the project. Get in [contact with us](/contact) to learn more or join this initiative
 

--- a/content/_index/blueprint/index.md
+++ b/content/_index/blueprint/index.md
@@ -1,10 +1,10 @@
 +++
 fragment = "content"
-title = "CDT.cloud Blueprint"
+title = "CDT Cloud Blueprint"
 weight = 160    
 background = "dark"
 
-#title = "CDT.cloud Blueprint"
+#title = "CDT Cloud Blueprint"
 #subtitle= "Column based items with icons"
 #title_align = "center" # Default is center, can be left, right or center
 +++
@@ -14,16 +14,16 @@ background = "dark"
 </div>
 
 <p style='text-align: center;'>
-CDT.cloud Blueprint is a template tool for building custom, web-based C/C++ tools. It is made of existing open source components and provides a typical C/C++ IDE based on the Eclipse Theia platform. This includes C/C++ language features, a language server, debugging support, memory debugging and a tracing view. It is meant to serve as a starting point for the implementation of domain-specific custom tools. For a simple showcase, CDT.cloud Blueprint can be easily downloaded and installed on all major operating system platforms.
+CDT Cloud Blueprint is a template tool for building custom, web-based C/C++ tools. It is made of existing open source components and provides a typical C/C++ IDE based on the Eclipse Theia platform. This includes C/C++ language features, a language server, debugging support, memory debugging and a tracing view. It is meant to serve as a starting point for the implementation of domain-specific custom tools. For a simple showcase, CDT Cloud Blueprint can be easily downloaded and installed on all major operating system platforms.
 </p>
-<p style='text-align: center;'>CDT.cloud Blueprint is <b>not a production-ready product</b>. Therefore, it is also not meant to be a replacement for Eclipse CDT or any other IDE (yet).</p>
+<p style='text-align: center;'>CDT Cloud Blueprint is <b>not a production-ready product</b>. Therefore, it is also not meant to be a replacement for Eclipse CDT or any other IDE (yet).</p>
 
 <div style='background: lavender;color: black;padding: 1rem'>
 
-CDT.cloud Blueprint is in an early alpha state and undergoing active development
+CDT Cloud Blueprint is in an early alpha state and undergoing active development
 
 * Check out the [development plan](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/milestone/1) for Release 1.0
-* For the current up to date development version of CDT.cloud Blueprint including a Docker based development build, see the [Github repository](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint)
+* For the current up to date development version of CDT Cloud Blueprint including a Docker based development build, see the [Github repository](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint)
 * Prereleases of CDT.Cloud Blueprint are available to be [downloaded and installed](https://download.eclipse.org/theia/cdt-cloud/)
 
 [Follow us on twitter](https://twitter.com/CdtCloud") to be notified about recent updates to the project. Get in [contact with us](/contact) to learn more or join this initiative

--- a/content/_index/features/compilationdebugging.md
+++ b/content/_index/features/compilationdebugging.md
@@ -6,4 +6,4 @@ weight = 20
   icon = "fas fa-play-circle"
 +++
 
-CDT.cloud Blueprint allows you to integrate any compiler of choice via the flexible task system. By default, it also provides support for CMake via the popular CMake VS Code extension. Furthermore, CDT.cloud Blueprint provides sophisticated debugging support enabled by the [Debug Adapter Protocol (DAP)](https://microsoft.github.io/debug-adapter-protocol/) and the [Eclipse CDT GDB DAP adapter](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter).
+CDT Cloud Blueprint allows you to integrate any compiler of choice via the flexible task system. By default, it also provides support for CMake via the popular CMake VS Code extension. Furthermore, CDT Cloud Blueprint provides sophisticated debugging support enabled by the [Debug Adapter Protocol (DAP)](https://microsoft.github.io/debug-adapter-protocol/) and the [Eclipse CDT GDB DAP adapter](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter).

--- a/content/_index/features/flexibleextensible.md
+++ b/content/_index/features/flexibleextensible.md
@@ -6,8 +6,8 @@ weight = 50
   icon = "fas fa-cogs"
 +++
 
-CDT.cloud Blueprint provides two extension mechanisms for maximum flexibility.
-First, CDT.cloud Blueprint supports VS Code extensions, e.g. to be installed from the [openVSX](https://open-vsx.org) marketplace.
-Therefore you can easily extend CDT.cloud Blueprint with additional features from the huge ecosystem.
-Second, by using Theia extensions, you can extend, adapt or even replace almost every aspect of CDT.cloud Blueprint.
+CDT Cloud Blueprint provides two extension mechanisms for maximum flexibility.
+First, CDT Cloud Blueprint supports VS Code extensions, e.g. to be installed from the [openVSX](https://open-vsx.org) marketplace.
+Therefore you can easily extend CDT Cloud Blueprint with additional features from the huge ecosystem.
+Second, by using Theia extensions, you can extend, adapt or even replace almost every aspect of CDT Cloud Blueprint.
 Therefore, you can fully customize the blueprint to your specific and domain-specific needs and create a fully custom and white-label tool.

--- a/content/_index/features/fullyopensource.md
+++ b/content/_index/features/fullyopensource.md
@@ -6,7 +6,7 @@ weight = 60
   icon = "fas fa-check-double"
 +++
 
-CDT.cloud Blueprint consists entirely of open source components.
+CDT Cloud Blueprint consists entirely of open source components.
 Even more, all components are released under licenses that are friendly to commercial use (mostly EPL and MIT).
-Therefore, you can adopt CDT.cloud Blueprint to build your own tool and provide it to your customers with a commercial license.
-Last but not least most components of CDT.cloud (e.g. Theia itself) are backed by the strong support of companies in the [Eclipse Cloud Dev Tools Working Group](https://ecdtools.eclipse.org).
+Therefore, you can adopt CDT Cloud Blueprint to build your own tool and provide it to your customers with a commercial license.
+Last but not least most components of CDT Cloud (e.g. Theia itself) are backed by the strong support of companies in the [Eclipse Cloud Dev Tools Working Group](https://ecdtools.eclipse.org).

--- a/content/_index/features/languagesupport.md
+++ b/content/_index/features/languagesupport.md
@@ -6,5 +6,5 @@ weight = 10
   icon = "fas fa-indent"
 +++
 
-CDT.cloud Blueprint provides state-of-the-art language support for C/C++ including syntax highlighting, inline errors and warnings, quick fixes, code completion, namespace and include insertion, code navigation, formatting, details on hover, formatting, refactoring and rename.
+CDT Cloud Blueprint provides state-of-the-art language support for C/C++ including syntax highlighting, inline errors and warnings, quick fixes, code completion, namespace and include insertion, code navigation, formatting, details on hover, formatting, refactoring and rename.
 All this is provided by the integrated [clangd language server](https://clangd.llvm.org/) based on the [clang compiler](https://clang.llvm.org/).

--- a/content/_index/features/memorytracing.md
+++ b/content/_index/features/memorytracing.md
@@ -6,7 +6,7 @@ weight = 30
   icon = "fas fa-memory"
 +++
 
-For memory debugging, CDT.cloud Blueprint integrates the powerful [memory inspector](https://github.com/eclipse-theia/theia-cpp-extensions/tree/master/packages/cpp-debug) provided by Eclipse Theia.
+For memory debugging, CDT Cloud Blueprint integrates the powerful [memory inspector](https://github.com/eclipse-theia/theia-cpp-extensions/tree/master/packages/cpp-debug) provided by Eclipse Theia.
 It allows you to display the current memory, view registers and compare memory from different regions or even different points in time.
 It even supports changing the memory on the fly while debugging.
-Furthermore, CDT.cloud Blueprint integrates the powerful [web version of TraceCompass](https://github.com/eclipse-cdt-cloud/theia-trace-extension), the popular open source tool for analyzing traces.
+Furthermore, CDT Cloud Blueprint integrates the powerful [web version of TraceCompass](https://github.com/eclipse-cdt-cloud/theia-trace-extension), the popular open source tool for analyzing traces.

--- a/content/_index/features/moderntechstack.md
+++ b/content/_index/features/moderntechstack.md
@@ -6,7 +6,7 @@ weight = 40
   icon = "fab fa-html5"
 +++
 
-CDT.cloud Blueprint is built on a modern technology stack.
+CDT Cloud Blueprint is built on a modern technology stack.
 The UI is implemented using HTML, CSS and JavaScript/TypeScript.
 The backend is based on Node.JS integrating other technologies such as a language server for C/C++.
 The underlying tool platform is Eclipse Theia providing the perfect base for extending and adapting the blueprint to your own domain-specific use case.

--- a/content/_index/hero.md
+++ b/content/_index/hero.md
@@ -6,8 +6,8 @@ weight = 100
 background = "dark" # can influence the text color
 particles = true
 
-title = "CDT.cloud Blueprint - a template for a web-based C/C++ tool"
-subtitle = "CDT.cloud Blueprint - a template for building web-based C/C++ tools"
+title = "CDT Cloud Blueprint - a template for a web-based C/C++ tool"
+subtitle = "CDT Cloud Blueprint - a template for building web-based C/C++ tools"
 
 [header]
 

--- a/content/_index/overview/blueprint.md
+++ b/content/_index/overview/blueprint.md
@@ -1,5 +1,5 @@
 +++
-title = "CDT.cloud Blueprint"
+title = "CDT Cloud Blueprint"
 weight = 10
 
 [asset]
@@ -7,4 +7,4 @@ weight = 10
   url = "#blueprint"
 +++
 
-CDT.cloud Blueprint is a template tool for building custom, web-based C/C++ tools
+CDT Cloud Blueprint is a template tool for building custom, web-based C/C++ tools

--- a/content/_index/overview/index.md
+++ b/content/_index/overview/index.md
@@ -3,7 +3,7 @@ fragment = "items"
 weight = 150    
 background = "white"
 
-title = "CDT.cloud"
-subtitle = "CDT.cloud hosts a growing number of components and best practices for building customizable web-based C/C++ tools"
+title = "CDT Cloud"
+subtitle = "CDT Cloud hosts a growing number of components and best practices for building customizable web-based C/C++ tools"
 #title_align = "center" # Default is center, can be left, right or center
 +++

--- a/content/contact/contactoptions/meetings.md
+++ b/content/contact/contactoptions/meetings.md
@@ -7,5 +7,5 @@ weight = 30
   url = "https://github.com/eclipse-cdt-cloud/cdt-cloud/blob/main/README.md#-meet-the-people-behind-cdtcloud"
 +++
 
-Connect with the people behind CDT.cloud in a virtual CDT.cloud community meeting.
-Dates are listed in the [CDT.cloud Readme on Github](https://github.com/eclipse-cdt-cloud/cdt-cloud/blob/main/README.md#-meet-the-people-behind-cdtcloud).
+Connect with the people behind CDT Cloud in a virtual CDT Cloud community meeting.
+Dates are listed in the [CDT Cloud Readme on Github](https://github.com/eclipse-cdt-cloud/cdt-cloud/blob/main/README.md#-meet-the-people-behind-cdtcloud).

--- a/content/documentation/_index/content.md
+++ b/content/documentation/_index/content.md
@@ -6,16 +6,16 @@ weight = 100
   sticky = true
 +++
 
-CDT.cloud hosts reusable components and best practices for building web-based, custom C/C++ tools based on a modern technology stack.
-Thus, CDT.cloud is not one single framework, but rather an ecosystem of platforms, components and frameworks that can be combined into a custom tool for a specific environment, e.g. an IDE for embedded software development with a specific family of boards.
+CDT Cloud hosts reusable components and best practices for building web-based, custom C/C++ tools based on a modern technology stack.
+Thus, CDT Cloud is not one single framework, but rather an ecosystem of platforms, components and frameworks that can be combined into a custom tool for a specific environment, e.g. an IDE for embedded software development with a specific family of boards.
 
-To learn more about building a custom tool with CDT.cloud, involved platforms, components and frameworks, please use the table of contents on the left to navigate through the documentation pages.
+To learn more about building a custom tool with CDT Cloud, involved platforms, components and frameworks, please use the table of contents on the left to navigate through the documentation pages.
 
 ➡️ A great starting point is the [Overview]({{< relref "overview" >}}) section.
 
-The source code of the CDT.cloud components is available on [GitHub](https://github.com/eclipse-cdt-cloud/cdt-cloud).
-With [CDT.cloud Blueprint]({{< relref  "/#blueprint" >}}), there is also an example tool that demonstrates a custom C/C++ tool based on CDT.cloud.
-Also check out the [additional external articles and videos about CDT.cloud]({{< relref  "additionals" >}}).
+The source code of the CDT Cloud components is available on [GitHub](https://github.com/eclipse-cdt-cloud/cdt-cloud).
+With [CDT Cloud Blueprint]({{< relref  "/#blueprint" >}}), there is also an example tool that demonstrates a custom C/C++ tool based on CDT Cloud.
+Also check out the [additional external articles and videos about CDT Cloud]({{< relref  "additionals" >}}).
 
 We are continuously working on improving this documentation. If you feel something is missing, please file an issue and open a PR at the [website repository](https://github.com/eclipse-cdt-cloud/website).
 

--- a/content/documentation/additionals/content.md
+++ b/content/documentation/additionals/content.md
@@ -18,8 +18,8 @@ Also, we provide a list of talk recordings and videos on CDT Cloud:
 * EclipseCon 2022: <a target="_blank" href="https://www.youtube.com/watch?v=zDDAu2LDxSs">Introducing Eclipse CDT Cloud - C/C++ tooling in the web</a>
 * EclipseCon 2022: <a target="_blank" href="https://www.youtube.com/watch?v=sNdsuxE5Q1Y">What's cooking in the TraceCompass cloud project</a>
 * Cloud IDE Days 2022: <a target="_blank" href="https://www.youtube.com/watch?v=zRZrv4c6lhk">Building Custom C/C++ Tools in the Web</a>
-* CDT.cloud Overview: <a target="_blank" href="https://www.youtube.com/watch?v=H3E46x8MzzQ">Elevator pitch</a>
-* CDT.cloud Overview: <a target="_blank" href="https://www.youtube.com/watch?v=1aO0pxCcUrk">Walkthrough</a>
-* Trace Compass.cloud: <a target="_blank" href="https://www.youtube.com/playlist?list=PL9c8Jxzvk1-lTdH79COvnzCwEPt3BFfo_">Several videos on Trace Compass.cloud 8.1</a>
+* CDT cloud Overview: <a target="_blank" href="https://www.youtube.com/watch?v=H3E46x8MzzQ">Elevator pitch</a>
+* CDT cloud Overview: <a target="_blank" href="https://www.youtube.com/watch?v=1aO0pxCcUrk">Walkthrough</a>
+* Trace Compass Cloud: <a target="_blank" href="https://www.youtube.com/playlist?list=PL9c8Jxzvk1-lTdH79COvnzCwEPt3BFfo_">Several videos on Trace Compass Cloud 8.1</a>
 * EclipseCon 2021: <a target="_blank" href="https://www.youtube.com/watch?v=cDPAl9nzAhg">CDT Cloud? C/C++ tooling in the web</a>
 * TheiaCon 2021: <a target="_blank" href="https://www.youtube.com/watch?v=v54NWrkWv7M">Theia for C/C++ and embedded development</a>

--- a/content/documentation/additionals/content.md
+++ b/content/documentation/additionals/content.md
@@ -8,18 +8,18 @@ title = "External Articles & Videos"
   sticky = true
 +++
 
-Below is a list of articles on CDT.cloud:
+Below is a list of articles on CDT Cloud:
 
-* <a target="_blank" href="https://eclipsesource.com/blogs/2021/11/26/cdt-cloud-c-c-tooling-in-the-web-cloud/">CDT.cloud? C/C++ tooling in the web/cloud</a>
-* <a target="_blank" href="https://eclipsesource.com/blogs/2022/01/10/cdt-cloud-an-overview-about-c-c-tooling-in-the-web/">CDT.cloud – An overview about C/C++ tooling in the web</a>
+* <a target="_blank" href="https://eclipsesource.com/blogs/2021/11/26/cdt-cloud-c-c-tooling-in-the-web-cloud/">CDT Cloud? C/C++ tooling in the web/cloud</a>
+* <a target="_blank" href="https://eclipsesource.com/blogs/2022/01/10/cdt-cloud-an-overview-about-c-c-tooling-in-the-web/">CDT Cloud – An overview about C/C++ tooling in the web</a>
 
-Also, we provide a list of talk recordings and videos on CDT.cloud:
+Also, we provide a list of talk recordings and videos on CDT Cloud:
 
-* EclipseCon 2022: <a target="_blank" href="https://www.youtube.com/watch?v=zDDAu2LDxSs">Introducing Eclipse CDT.cloud - C/C++ tooling in the web</a>
+* EclipseCon 2022: <a target="_blank" href="https://www.youtube.com/watch?v=zDDAu2LDxSs">Introducing Eclipse CDT Cloud - C/C++ tooling in the web</a>
 * EclipseCon 2022: <a target="_blank" href="https://www.youtube.com/watch?v=sNdsuxE5Q1Y">What's cooking in the TraceCompass cloud project</a>
 * Cloud IDE Days 2022: <a target="_blank" href="https://www.youtube.com/watch?v=zRZrv4c6lhk">Building Custom C/C++ Tools in the Web</a>
 * CDT.cloud Overview: <a target="_blank" href="https://www.youtube.com/watch?v=H3E46x8MzzQ">Elevator pitch</a>
 * CDT.cloud Overview: <a target="_blank" href="https://www.youtube.com/watch?v=1aO0pxCcUrk">Walkthrough</a>
 * Trace Compass.cloud: <a target="_blank" href="https://www.youtube.com/playlist?list=PL9c8Jxzvk1-lTdH79COvnzCwEPt3BFfo_">Several videos on Trace Compass.cloud 8.1</a>
-* EclipseCon 2021: <a target="_blank" href="https://www.youtube.com/watch?v=cDPAl9nzAhg">CDT.cloud? C/C++ tooling in the web</a>
+* EclipseCon 2021: <a target="_blank" href="https://www.youtube.com/watch?v=cDPAl9nzAhg">CDT Cloud? C/C++ tooling in the web</a>
 * TheiaCon 2021: <a target="_blank" href="https://www.youtube.com/watch?v=v54NWrkWv7M">Theia for C/C++ and embedded development</a>

--- a/content/documentation/blueprint/content.md
+++ b/content/documentation/blueprint/content.md
@@ -2,19 +2,19 @@
 fragment = "content"
 weight = 30
 
-title = "CDT.cloud Blueprint"
+title = "CDT Cloud Blueprint"
 
 [sidebar]
   sticky = true
 +++
 
-CDT.cloud Blueprint is a template tool for building custom, web-based C/C++ tools.
+CDT Cloud Blueprint is a template tool for building custom, web-based C/C++ tools.
 It is based on the [Theia development tool platform]({{< relref  "tool-platform" >}}) and integrates several existing open source components to provide a starting point for building a custom C/C++ IDE.
 This includes C/C++ language features, debugging support, a memory inspector, and a tracing view.
 
-The purpose of CDT.cloud Blueprint is two-fold:
+The purpose of CDT Cloud Blueprint is two-fold:
 
-1. You can download and run it to try out several CDT.cloud components (see [download page](/#blueprint))
+1. You can download and run it to try out several CDT Cloud components (see [download page](/#blueprint))
 2. You can use it as a template to start off your custom C/C++ tool (see instructions below)
 
 <p align="center" style="padding-top: 1em; padding-bottom: 1em">
@@ -23,12 +23,12 @@ The purpose of CDT.cloud Blueprint is two-fold:
 
 ### Building and running
 
-The sources including build instructions are available on the [CDT.cloud Blueprint Github repository](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint).
-Please follow the instructions on the [Github readme](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/blob/master/README.md) to build and run CDT.cloud Blueprint as a desktop app, browser app, or in Docker.
+The sources including build instructions are available on the [CDT Cloud Blueprint Github repository](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint).
+Please follow the instructions on the [Github readme](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/blob/master/README.md) to build and run CDT Cloud Blueprint as a desktop app, browser app, or in Docker.
 
 ### Selection of common VS Code extensions
 
-To provide common capabilities for developing C/C++ projects, CDT.cloud blueprint installs several open-source VS Code extensions that are typically useful in the context of C/C++ development.
+To provide common capabilities for developing C/C++ projects, CDT Cloud blueprint installs several open-source VS Code extensions that are typically useful in the context of C/C++ development.
 This includes the following and more.
 
 * [vscode-clangd](https://github.com/clangd/vscode-clangd): Integration of the C/C++ language server *clangd*
@@ -40,7 +40,7 @@ For a complete list of the used Theia extensions and VS Code extensions, please 
 
 ### Welcome page
 
-To greet and guide users on initial start-up of CDT.cloud Blueprint, it provides a welcome page.
+To greet and guide users on initial start-up of CDT Cloud Blueprint, it provides a welcome page.
 The welcome page is essentially a web page in a Theia view that provides general information, but also links to relevant web resources.
 Users can also trigger commands directly from the welcome page, such as opening folders, settings, as well as [creating example projects](#example-project-generator).
 
@@ -48,8 +48,8 @@ The welcome page is contributed to the product in the [TheiaBlueprintGettingStar
 
 ### Example project generator
 
-CDT.cloud Blueprint contains an example generator which allows users to create pre-defined projects based on a project template.
-Projects can either be generated from the welcome page or via the command *Generate CDT.cloud Blueprint Example*.
+CDT Cloud Blueprint contains an example generator which allows users to create pre-defined projects based on a project template.
+Projects can either be generated from the welcome page or via the command *Generate CDT Cloud Blueprint Example*.
 Once a project is generated, a defined file -- such as a readme -- of this project is opened for the user.
 The generator is implemented by the Theia extension [`blueprint-example-generator`](https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/blob/master/theia-extensions/blueprint-example-generator).
 

--- a/content/documentation/blueprint/index.md
+++ b/content/documentation/blueprint/index.md
@@ -1,4 +1,4 @@
 +++
-title = "CDT.cloud Blueprint"
+title = "CDT Cloud Blueprint"
 weight = 30
 +++

--- a/content/documentation/overview/content.md
+++ b/content/documentation/overview/content.md
@@ -12,9 +12,9 @@ title = "Overview"
   <img src="/images/diagramanimated.gif" width="60%" style="border-radius: 5px" />
 </p>
 
-### Why do I need CDT.cloud?
+### Why do I need CDT Cloud?
 
-CDT.cloud provides business-friendly open source software components for building custom web-based C/C++ development tools, running in the cloud or on the desktop.
+CDT Cloud provides business-friendly open source software components for building custom web-based C/C++ development tools, running in the cloud or on the desktop.
 Such custom development tools make it easy for your users to work with specific devices, toolchains, or libraries, etc.
 With a custom tool that is optimized for a specific purpose, you can achieve a great developer experience for your users by including, for instance, ...
 
@@ -24,19 +24,19 @@ With a custom tool that is optimized for a specific purpose, you can achieve a g
 * easy-to-use debug configurations or other analysis capabilities, such as memory inspectors or trace viewers,
 * and much more.
 
-### How does CDT.cloud help?
+### How does CDT Cloud help?
 
 Custom C/C++ development tools have several reoccuring capabilities, such as creating projects, editing source code, building projects, debugging and tracing applications, etc.
 While they may differ from one specific tool use case to another, the base components can still be reused and adapted to the specifics of an environment.
 This makes building such tools significantly more efficient.
-And that's precisely where CDT.cloud is here to help: it provides a feature-rich ecosystem of reusable platforms and components that can be customized for your environment and bundled into a ready-to-use tool product for your use case.
+And that's precisely where CDT Cloud is here to help: it provides a feature-rich ecosystem of reusable platforms and components that can be customized for your environment and bundled into a ready-to-use tool product for your use case.
 
 ### How do I get started?
 
 In most cases, a great starting point is to select a [development tool platform]({{< relref  "tool-platform" >}}) for your custom tool.
 A development tool platform, such as Eclipse Theia or VS Code, provides the common capabilities of a code editing tool, such as a file explorer, code editor or git integration, which you may also need in your custom tool.
 For your custom tool, you can then augment this tool platform with extensions too add additional tool capabilities and customize it to your specific requirements.
-CDT.cloud also provides an example tool named [CDT.cloud Blueprint]({{< relref  "blueprint" >}}), which may act as a template and a source of inspiration for your specific tool.
+CDT Cloud also provides an example tool named [CDT Cloud Blueprint]({{< relref  "blueprint" >}}), which may act as a template and a source of inspiration for your specific tool.
 
 For more details on those steps, please refer to the table of contents to the left.
 If you need help to get started, [contact us](/contact)!

--- a/content/documentation/tool-platform/content.md
+++ b/content/documentation/tool-platform/content.md
@@ -23,7 +23,7 @@ Whether to use one or the other for a specific tool project depends on [various 
 In a nutshell, if you rather want to provide an extension to an existing code editor rather than creating an own product, VS Code may be a good choice for your project.
 If you want, however, to provide a white-labeled, tailored product for your customers or your own developers and you need to be able to take control over several aspects of your tool, you might be better served with Eclipse Theia.
 
-As the decision on VS Code vs Eclipse Theia depends on the respective tool project, many of the CDT.cloud components are actually shipped as VS Code extensions.
+As the decision on VS Code vs Eclipse Theia depends on the respective tool project, many of the CDT Cloud components are actually shipped as VS Code extensions.
 This way, they can be used either way, whether you use VS Code or Eclipse Theia.
 
 With custom C/C++ development tools, however, you often need to have full control over every aspect of your custom tool, which makes Theia is a popular choice in this context.
@@ -34,9 +34,9 @@ Thus, we point you to the right resources to get started with Theia below.
 To learn more about Theia, please visit the [Theia webpage](https://theia-ide.org) and browse through its [getting started guide](https://theia-ide.org/docs/getting_started).
 This will give you a solid overview about Theia's architecture and main concepts.
 
-For your custom C/C++ tool, we recommend to start off from the [CDT.cloud Blueprint]({{< relref  "blueprint" >}}) and use it as a template.
-CDT.cloud Blueprint is a Theia-based application which already contains a collection of extensions and configurations that likely apply to your C/C++ tool use case.
-Thus, all documentation on Theia applies to CDT.cloud Blueprint as well, but it already adds components and best practices that typically are useful for C/C++ tools.
+For your custom C/C++ tool, we recommend to start off from the [CDT Cloud Blueprint]({{< relref  "blueprint" >}}) and use it as a template.
+CDT Cloud Blueprint is a Theia-based application which already contains a collection of extensions and configurations that likely apply to your C/C++ tool use case.
+Thus, all documentation on Theia applies to CDT Cloud Blueprint as well, but it already adds components and best practices that typically are useful for C/C++ tools.
 
 To learn more about composing Theia-based applications in general, please refer to the [Theia documentation](https://theia-ide.org/docs/composing_applications).
 
@@ -56,4 +56,4 @@ For an overview, please read more about the [Theia extension mechanisms](https:/
 
 When you want to package your custom tool as a desktop application, you'll need to build your entire application for the operating systems you aim to support and likely want to integrate an update mechanism and add branding, such as application icons, etc.
 To learn more about dealing with those tasks, please consult the [Theia packaging documentation](https://theia-ide.org/docs/blueprint_documentation).
-You can also check the CDT.cloud Blueprint for a concrete implementation.
+You can also check the CDT Cloud Blueprint for a concrete implementation.

--- a/content/support/content.md
+++ b/content/support/content.md
@@ -6,6 +6,6 @@ background = "white"
 
 +++
 <p style="text-align: center;">
-Support for CDT.cloud Blueprint and for projects adopting it and building custom C/C++ tools is provided by the community, by the contributors of CDT.cloud Blueprint and members of the Eclipse Cloud Development working group:
+Support for CDT Cloud Blueprint and for projects adopting it and building custom C/C++ tools is provided by the community, by the contributors of CDT Cloud Blueprint and members of the Eclipse Cloud Development working group:
 </p>
 

--- a/content/support/examples/professionalsupport.md
+++ b/content/support/examples/professionalsupport.md
@@ -9,7 +9,7 @@ weight = 20
 <a href="https://eclipsesource.com/technology/c-c-tooling/">
 <img src="../images/eslogo.png" alt="EclipseSource Logo" width="200" style="display: block; margin: auto;" /></a>
 
-**Adaptations to CDT.cloud Blueprint**\
+**Adaptations to CDT Cloud Blueprint**\
 **Implementation of custom C/C++ tools**\
 **In-depth answers**\
 **Private communication (NDA)**


### PR DESCRIPTION
Now as the rename of the project has been approved (see https://gitlab.eclipse.org/eclipsefdn/emo-team/emo/-/issues/440), we can apply the changes to the website.