### PR TITLE
Change URLs from eclipse.org to eclipse.dev

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://www.eclipse.org/cdt-cloud"
+baseURL = "https://www.eclipse.dev/cdt-cloud"
 DefaultContentLanguage = "en"
 title = "CDT Cloud Blueprint"
 theme = "syna"
@@ -86,7 +86,7 @@ lastmod = ["lastmod", ":git", "date"]
   weight = 10
 
 [[menu.footer]]
-  url = "https://www.eclipse.org/tracecompass/"
+  url = "https://www.eclipse.dev/tracecompass/"
   name = "Eclipse Trace Compass"
   weight = 20
 


### PR DESCRIPTION
More information on this migration can be found at https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3069